### PR TITLE
Adding UriTemplate Test Tool Kit

### DIFF
--- a/feignx-core/pom.xml
+++ b/feignx-core/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>slf4j-nop</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/feignx-core/src/main/java/feign/Feign.java
+++ b/feignx-core/src/main/java/feign/Feign.java
@@ -1,9 +1,9 @@
 package feign;
 
+import feign.ExceptionHandler.RethrowExceptionHandler;
 import feign.contract.FeignContract;
 import feign.decoder.StringDecoder;
 import feign.encoder.StringEncoder;
-import feign.ExceptionHandler.RethrowExceptionHandler;
 import feign.http.client.UrlConnectionClient;
 import feign.impl.AbstractFeignConfigurationBuilder;
 import feign.impl.BaseFeignConfiguration;

--- a/feignx-core/src/main/java/feign/impl/AbstractTarget.java
+++ b/feignx-core/src/main/java/feign/impl/AbstractTarget.java
@@ -65,7 +65,7 @@ public abstract class AbstractTarget<T> implements Target<T> {
    *
    * @param obj to compare.
    * @return {@literal true} if the provided object is equal to this instance, {@literal false}
-   * otherwise.
+   *        otherwise.
    */
   @Override
   public boolean equals(Object obj) {
@@ -76,8 +76,8 @@ public abstract class AbstractTarget<T> implements Target<T> {
       return false;
     }
     AbstractTarget<?> that = (AbstractTarget<?>) obj;
-    return type.equals(that.type) &&
-        name.equals(that.name);
+    return type.equals(that.type)
+        && name.equals(that.name);
   }
 
   @Override

--- a/feignx-core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
+++ b/feignx-core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
@@ -161,7 +161,7 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
    *
    * @param arguments to map.
    * @return a new Map, where the argument is matched up to the corresponding Template parameter
-   * name.
+   *        name.
    */
   private Map<String, Object> mapArguments(Object[] arguments) {
     Map<String, Object> variables = new LinkedHashMap<>();

--- a/feignx-core/src/main/java/feign/impl/BlockingTargetMethodHandler.java
+++ b/feignx-core/src/main/java/feign/impl/BlockingTargetMethodHandler.java
@@ -1,13 +1,13 @@
 package feign.impl;
 
 import feign.Client;
+import feign.ExceptionHandler;
 import feign.Logger;
 import feign.RequestEncoder;
 import feign.RequestInterceptor;
 import feign.Response;
 import feign.ResponseDecoder;
 import feign.TargetMethodDefinition;
-import feign.ExceptionHandler;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RunnableFuture;

--- a/feignx-core/src/main/java/feign/logging/SimpleLogger.java
+++ b/feignx-core/src/main/java/feign/logging/SimpleLogger.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 /**
- * Simple Logger implementation backed by SLF4J
+ * Simple Logger implementation backed by SLF4J.
  */
 public class SimpleLogger extends AbstractLogger {
 
@@ -54,30 +54,54 @@ public class SimpleLogger extends AbstractLogger {
     private boolean responseEnabled = false;
     private boolean headersEnabled = false;
 
+    /**
+     * Set if Logging should be enabled.
+     *
+     * @param enabled flag.
+     * @return the builder chain.
+     */
     public Builder setEnabled(boolean enabled) {
       this.enabled = enabled;
       return this;
     }
 
+    /**
+     * Set if Request information should be logged.
+     *
+     * @param requestEnabled flag.
+     * @return the builder chain.
+     */
     public Builder setRequestEnabled(boolean requestEnabled) {
       this.enabled = true;
       this.requestEnabled = requestEnabled;
       return this;
     }
 
+    /**
+     * Set if Response information should be logged.
+     *
+     * @param responseEnabled flag.
+     * @return the builder chain.
+     */
     public Builder setResponseEnabled(boolean responseEnabled) {
       this.enabled = true;
       this.responseEnabled = responseEnabled;
       return this;
     }
 
+    /**
+     * Set if Header information should be logged.
+     *
+     * @param headersEnabled flag.
+     * @return the builder chain.
+     */
     public Builder setHeadersEnabled(boolean headersEnabled) {
       this.enabled = true;
       this.headersEnabled = headersEnabled;
       return this;
     }
 
-    public SimpleLogger build(){
+    public SimpleLogger build() {
       return new SimpleLogger(this.enabled, this.requestEnabled, this.responseEnabled,
           this.headersEnabled);
     }

--- a/feignx-core/src/main/java/feign/proxy/ProxyTarget.java
+++ b/feignx-core/src/main/java/feign/proxy/ProxyTarget.java
@@ -47,7 +47,7 @@ public class ProxyTarget<T> implements InvocationHandler, Target<T> {
   }
 
   /**
-   * Creates a new {@link ProxyTarget}
+   * Creates a new {@link ProxyTarget}.
    *
    * @param methods for this proxy to manage.
    * @param methodHandlerFactory to use when creating method handlers.

--- a/feignx-core/src/main/java/feign/support/StringUtils.java
+++ b/feignx-core/src/main/java/feign/support/StringUtils.java
@@ -10,7 +10,7 @@ public class StringUtils {
    *
    * @param value to evaluate.
    * @return {@literal true} if the value is not empty or {@literal null}, {@literal false}
-   * otherwise.
+   *        otherwise.
    */
   public static boolean isNotEmpty(String value) {
     return value != null && !value.isEmpty();
@@ -20,8 +20,7 @@ public class StringUtils {
    * Determines if the provided String is empty or {@literal null}.
    *
    * @param value to evaluate.
-   * @return {@literal true} if the value is empty or {@literal null}, {@literal false}
-   * otherwise.
+   * @return {@literal true} if the value is empty or {@literal null}, {@literal false} otherwise.
    */
   public static boolean isEmpty(String value) {
     return value == null || value.isEmpty();

--- a/feignx-core/src/main/java/feign/template/CompositeExpression.java
+++ b/feignx-core/src/main/java/feign/template/CompositeExpression.java
@@ -1,0 +1,70 @@
+package feign.template;
+
+import feign.support.StringUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Expression that contains multiple expressions.
+ */
+public class CompositeExpression extends Expression {
+
+  private final List<Expression> expressions = new ArrayList<>();
+  private String prefix;
+  private String delimiter;
+
+  CompositeExpression(String variableSpecification) {
+    super(variableSpecification);
+  }
+
+  void append(Expression expression) {
+    this.expressions.add(expression);
+  }
+
+  void setPrefix(String prefix) {
+    this.prefix = prefix;
+  }
+
+  void setDelimiter(String delimiter) {
+    this.delimiter = delimiter;
+  }
+
+  @Override
+  protected boolean isCharacterAllowed(char character) {
+    /* if it is allowed by any of the contained expressions, it's allowed */
+    return this.expressions.stream()
+        .anyMatch(expression -> expression.isCharacterAllowed(character));
+  }
+
+  @Override
+  protected String getDelimiter() {
+    return this.delimiter;
+  }
+
+  @Override
+  protected String getPrefix() {
+    return this.prefix;
+  }
+
+  @Override
+  String expand(Map<String, ?> variables) {
+    StringBuilder expansion = new StringBuilder();
+    for (Expression value : this.expressions) {
+      String expanded = value.expand(variables);
+
+      if (expanded != null) {
+        /* append the delimiter */
+        this.appendDelimiter(expansion, this.getDelimiter());
+
+        /* remove the prefix, if one is present, we will add it to the composite */
+        if (StringUtils.isNotEmpty(this.getPrefix()) && expanded.startsWith(this.getPrefix())) {
+          expanded = expanded.substring(1);
+        }
+        expansion.append(expanded);
+      }
+    }
+
+    return this.getPrefix() + expansion.toString();
+  }
+}

--- a/feignx-core/src/main/java/feign/template/UriUtils.java
+++ b/feignx-core/src/main/java/feign/template/UriUtils.java
@@ -111,6 +111,13 @@ public class UriUtils {
    * @return {@literal true} if the value is already pct-encoded, {@literal false} otherwise.
    */
   public static boolean isPctEncoded(String value) {
+    for (byte b : value.getBytes(StandardCharsets.UTF_8)) {
+      if (!isUnreserved((char) b) && b != '%') {
+        /* break if there are any unreserved character */
+        return false;
+      }
+    }
+    /* check if the entire string is already encoded */
     return PCT_ENCODED_PATTERN.matcher(value).find();
   }
 

--- a/feignx-core/src/test/java/feign/template/UriTemplateTckTests.java
+++ b/feignx-core/src/test/java/feign/template/UriTemplateTckTests.java
@@ -1,0 +1,86 @@
+package feign.template;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.template.tck.TestCase;
+import feign.template.tck.TestGroup;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test Cases that use the TCK provided by
+ * <a href="https://github.com/uri-templates/uritemplate-test">uri-templates/uritemplate-tests</a>
+ */
+class UriTemplateTckTests {
+
+  private static final Logger logger = LoggerFactory.getLogger(UriTemplateTckTests.class);
+  private static final List<String> testDefinitions = Arrays.asList(
+      "/template/spec-examples.json",
+      "/template/spec-examples-by-section.json",
+      "/template/negative-tests.json",
+      "/template/extended-tests.json",
+      "/template/feign-tests.json");
+  private static Map<String, TestGroup> examples = new LinkedHashMap<>();
+
+  /**
+   * Read in the {@link feign.template.tck.TestExamples} defined in the test definitions.
+   */
+  @BeforeAll
+  static void prepareTestDefinitions() {
+    Class<?> clazz = UriTemplateTckTests.class;
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    for (String definition : testDefinitions) {
+      try {
+        TypeReference<HashMap<String, TestGroup>> typeReference =
+            new TypeReference<HashMap<String, TestGroup>>() {};
+        Map<String, TestGroup> map = objectMapper.readValue(
+            clazz.getResourceAsStream(definition), typeReference);
+        examples.putAll(map);
+      } catch (Exception ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+  }
+
+  @Test
+  void verify() {
+    AtomicInteger failureCount = new AtomicInteger(0);
+    examples.forEach((name, testGroup) -> {
+
+      /* create a new uri template from test group */
+      Map<String, Object> variables = testGroup.getVariables();
+      for (TestCase testCase : testGroup.getTestCases()) {
+        try {
+          UriTemplate uriTemplate = UriTemplate.create(testCase.getExpression());
+          String result = uriTemplate.expand(variables).toString();
+          if (!testCase.getResults().contains(result)) {
+            throw new IllegalStateException("Result: " + result + " not found in: " + testCase.getResults());
+          } else {
+            logger.info("Test Passed: " + name + ": " + testCase.getExpression() + ": " + result);
+          }
+        } catch (Exception ex) {
+          if (!testCase.getResults().contains("false")) {
+            failureCount.incrementAndGet();
+            System.err.println("Test Case Failed: " + name + ":" + testGroup.getLevel() + ": " + testCase.getExpression() + ": " + ex.getClass().getName() + ":" + ex.getMessage());
+          } else {
+            logger.info("Test Passed: " + name + ": " + testCase.getExpression() + ": failure");
+          }
+        }
+      }
+    });
+    if (failureCount.intValue() != 0) {
+      fail("UriTemplate Verification Failed.");
+    }
+  }
+}

--- a/feignx-core/src/test/java/feign/template/tck/TestCase.java
+++ b/feignx-core/src/test/java/feign/template/tck/TestCase.java
@@ -1,0 +1,41 @@
+package feign.template.tck;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class TestCase {
+
+  private String expression;
+  private List<String> results = new ArrayList<>();
+
+  protected TestCase() {
+    super();
+  }
+
+  @SuppressWarnings("unchecked")
+  @JsonCreator
+  protected TestCase(List<Object> values) {
+    this.expression = (String) values.get(0);
+
+    if (List.class.isAssignableFrom(values.get(1).getClass())) {
+      this.results.addAll((List) values.get(1));
+    } else if (Boolean.class.isAssignableFrom(values.get(1).getClass())) {
+      this.results.add(((Boolean) values.get(1)).toString());
+    } else {
+
+      this.results.add((String) values.get(1));
+    }
+  }
+
+  public String getExpression() {
+    return expression;
+  }
+
+
+  public List<String> getResults() {
+    return results;
+  }
+
+}

--- a/feignx-core/src/test/java/feign/template/tck/TestExamples.java
+++ b/feignx-core/src/test/java/feign/template/tck/TestExamples.java
@@ -1,0 +1,23 @@
+package feign.template.tck;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class TestExamples {
+
+  private Map<String, TestGroup> testGroups;
+
+  protected TestExamples() {
+    super();
+    this.testGroups = new LinkedHashMap<>();
+  }
+
+  public Map<String, TestGroup> getTestGroups() {
+    return testGroups;
+  }
+
+  public void setTestGroups(
+      Map<String, TestGroup> testGroups) {
+    this.testGroups = testGroups;
+  }
+}

--- a/feignx-core/src/test/java/feign/template/tck/TestGroup.java
+++ b/feignx-core/src/test/java/feign/template/tck/TestGroup.java
@@ -1,0 +1,46 @@
+package feign.template.tck;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestGroup {
+
+  private String level;
+  private Map<String, Object> variables;
+
+  @JsonProperty("testcases")
+  private List<TestCase> testCases;
+
+  protected TestGroup() {
+    super();
+    this.variables = new LinkedHashMap<>();
+    this.testCases = new ArrayList<>();
+  }
+
+  public String getLevel() {
+    return level;
+  }
+
+  public void setLevel(String level) {
+    this.level = level;
+  }
+
+  public Map<String, Object> getVariables() {
+    return variables;
+  }
+
+  public void setVariables(Map<String, Object> variables) {
+    this.variables = variables;
+  }
+
+  public List<TestCase> getTestCases() {
+    return testCases;
+  }
+
+  public void setTestCases(List<TestCase> testCases) {
+    this.testCases = testCases;
+  }
+}

--- a/feignx-core/src/test/resources/template/extended-tests.json
+++ b/feignx-core/src/test/resources/template/extended-tests.json
@@ -1,0 +1,277 @@
+{
+  "Additional Examples 1": {
+    "level": 4,
+    "variables": {
+      "id": "person",
+      "token": "12345",
+      "fields": [
+        "id",
+        "name",
+        "picture"
+      ],
+      "format": "json",
+      "q": "URI Templates",
+      "page": "5",
+      "lang": "en",
+      "geocode": [
+        "37.76",
+        "-122.427"
+      ],
+      "first_name": "John",
+      "last.name": "Doe",
+      "Some%20Thing": "foo",
+      "number": 6,
+      "long": 37.76,
+      "lat": -122.427,
+      "group_id": "12345",
+      "query": "PREFIX dc: <http://purl.org/dc/elements/1.1/> SELECT ?book ?who WHERE { ?book dc:creator ?who }",
+      "uri": "http://example.org/?uri=http%3A%2F%2Fexample.org%2F",
+      "word": "drücken",
+      "Stra%C3%9Fe": "Grüner Weg",
+      "random": "šöäŸœñê€£¥‡ÑÒÓÔÕÖ×ØÙÚàáâãäåæçÿ",
+      "assoc_special_chars": {
+        "šöäŸœñê€£¥‡ÑÒÓÔÕ": "Ö×ØÙÚàáâãäåæçÿ"
+      }
+    },
+    "testcases": [
+      [
+        "{/id*}",
+        "/person"
+      ],
+      [
+        "{/id*}{?fields,first_name,last.name,token}",
+        [
+          "/person?fields=id,name,picture&first_name=John&last.name=Doe&token=12345",
+          "/person?fields=id,picture,name&first_name=John&last.name=Doe&token=12345",
+          "/person?fields=picture,name,id&first_name=John&last.name=Doe&token=12345",
+          "/person?fields=picture,id,name&first_name=John&last.name=Doe&token=12345",
+          "/person?fields=name,picture,id&first_name=John&last.name=Doe&token=12345",
+          "/person?fields=name,id,picture&first_name=John&last.name=Doe&token=12345"
+        ]
+      ],
+      [
+        "/search.{format}{?q,geocode,lang,locale,page,result_type}",
+        [
+          "/search.json?q=URI%20Templates&geocode=37.76,-122.427&lang=en&page=5",
+          "/search.json?q=URI%20Templates&geocode=-122.427,37.76&lang=en&page=5"
+        ]
+      ],
+      [
+        "/test{/Some%20Thing}",
+        "/test/foo"
+      ],
+      [
+        "/set{?number}",
+        "/set?number=6"
+      ],
+      [
+        "/loc{?long,lat}",
+        "/loc?long=37.76&lat=-122.427"
+      ],
+      [
+        "/base{/group_id,first_name}/pages{/page,lang}{?format,q}",
+        "/base/12345/John/pages/5/en?format=json&q=URI%20Templates"
+      ],
+      [
+        "/sparql{?query}",
+        "/sparql?query=PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20SELECT%20%3Fbook%20%3Fwho%20WHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D"
+      ],
+      [
+        "/go{?uri}",
+        "/go?uri=http%3A%2F%2Fexample.org%2F%3Furi%3Dhttp%253A%252F%252Fexample.org%252F"
+      ],
+      [
+        "/service{?word}",
+        "/service?word=dr%C3%BCcken"
+      ],
+      [
+        "/lookup{?Stra%C3%9Fe}",
+        "/lookup?Stra%C3%9Fe=Gr%C3%BCner%20Weg"
+      ],
+      [
+        "{random}",
+        "%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"
+      ],
+      [
+        "{?assoc_special_chars*}",
+        "?%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95=%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"
+      ]
+    ]
+  },
+  "Additional Examples 2": {
+    "level": 4,
+    "variables": {
+      "id": [
+        "person",
+        "albums"
+      ],
+      "token": "12345",
+      "fields": [
+        "id",
+        "name",
+        "picture"
+      ],
+      "format": "atom",
+      "q": "URI Templates",
+      "page": "10",
+      "start": "5",
+      "lang": "en",
+      "geocode": [
+        "37.76",
+        "-122.427"
+      ]
+    },
+    "testcases": [
+      [
+        "{/id*}",
+        [
+          "/person/albums",
+          "/albums/person"
+        ]
+      ],
+      [
+        "{/id*}{?fields,token}",
+        [
+          "/person/albums?fields=id,name,picture&token=12345",
+          "/person/albums?fields=id,picture,name&token=12345",
+          "/person/albums?fields=picture,name,id&token=12345",
+          "/person/albums?fields=picture,id,name&token=12345",
+          "/person/albums?fields=name,picture,id&token=12345",
+          "/person/albums?fields=name,id,picture&token=12345",
+          "/albums/person?fields=id,name,picture&token=12345",
+          "/albums/person?fields=id,picture,name&token=12345",
+          "/albums/person?fields=picture,name,id&token=12345",
+          "/albums/person?fields=picture,id,name&token=12345",
+          "/albums/person?fields=name,picture,id&token=12345",
+          "/albums/person?fields=name,id,picture&token=12345"
+        ]
+      ]
+    ]
+  },
+  "Additional Examples 3: Empty Variables": {
+    "variables": {
+      "empty_list": [],
+      "empty_assoc": {}
+    },
+    "testcases": [
+      [
+        "{/empty_list}",
+        [
+          ""
+        ]
+      ],
+      [
+        "{/empty_list*}",
+        [
+          ""
+        ]
+      ],
+      [
+        "{?empty_list}",
+        [
+          ""
+        ]
+      ],
+      [
+        "{?empty_list*}",
+        [
+          ""
+        ]
+      ],
+      [
+        "{?empty_assoc}",
+        [
+          ""
+        ]
+      ],
+      [
+        "{?empty_assoc*}",
+        [
+          ""
+        ]
+      ]
+    ]
+  },
+  "Additional Examples 4: Numeric Keys": {
+    "variables": {
+      "42": "The Answer to the Ultimate Question of Life, the Universe, and Everything",
+      "1337": [
+        "leet",
+        "as",
+        "it",
+        "can",
+        "be"
+      ],
+      "german": {
+        "11": "elf",
+        "12": "zwölf"
+      }
+    },
+    "testcases": [
+      [
+        "{42}",
+        "The%20Answer%20to%20the%20Ultimate%20Question%20of%20Life%2C%20the%20Universe%2C%20and%20Everything"
+      ],
+      [
+        "{?42}",
+        "?42=The%20Answer%20to%20the%20Ultimate%20Question%20of%20Life%2C%20the%20Universe%2C%20and%20Everything"
+      ],
+      [
+        "{1337}",
+        "leet,as,it,can,be"
+      ],
+      [
+        "{?1337*}",
+        "?1337=leet&1337=as&1337=it&1337=can&1337=be"
+      ],
+      [
+        "{?german*}",
+        [
+          "?11=elf&12=zw%C3%B6lf",
+          "?12=zw%C3%B6lf&11=elf"
+        ]
+      ]
+    ]
+  },
+  "Additional Examples 5: Explode Combinations": {
+    "variables": {
+      "id": "admin",
+      "token": "12345",
+      "tab": "overview",
+      "keys": {
+        "key1": "val1",
+        "key2": "val2"
+      }
+    },
+    "testcases": [
+      [
+        "{?id,token,keys*}",
+        [
+          "?id=admin&token=12345&key1=val1&key2=val2",
+          "?id=admin&token=12345&key2=val2&key1=val1"
+        ]
+      ],
+      [
+        "{/id}{?token,keys*}",
+        [
+          "/admin?token=12345&key1=val1&key2=val2",
+          "/admin?token=12345&key2=val2&key1=val1"
+        ]
+      ],
+      [
+        "{?id,token}{&keys*}",
+        [
+          "?id=admin&token=12345&key1=val1&key2=val2",
+          "?id=admin&token=12345&key2=val2&key1=val1"
+        ]
+      ],
+      [
+        "/user{/id}{?token,tab}{&keys*}",
+        [
+          "/user/admin?token=12345&tab=overview&key1=val1&key2=val2",
+          "/user/admin?token=12345&tab=overview&key2=val2&key1=val1"
+        ]
+      ]
+    ]
+  }
+}

--- a/feignx-core/src/test/resources/template/feign-tests.json
+++ b/feignx-core/src/test/resources/template/feign-tests.json
@@ -1,0 +1,23 @@
+{
+  "Feign Specific Examples: Complex Variable Names": {
+    "level": 4,
+    "variables": {
+      "list[]": [
+        "red",
+        "green",
+        "blue"
+      ],
+      "$data": "data"
+    },
+    "testcases": [
+      [
+        "{?list[]}",
+        "?list%5B%5D=red,green,blue"
+      ],
+      [
+        "{?list[]*}",
+        "?list%5B%5D=red&list%5B%5D=green&list%5B%5D=blue"
+      ]
+    ]
+  }
+}

--- a/feignx-core/src/test/resources/template/negative-tests.json
+++ b/feignx-core/src/test/resources/template/negative-tests.json
@@ -1,0 +1,57 @@
+{
+    "Failure Tests":{
+        "level":4,
+        "variables":{
+            "id"                : "thing",
+            "var"               : "value",
+            "hello"             : "Hello World!",
+            "with space"        : "fail",
+            " leading_space"    : "Hi!",
+            "trailing_space "   : "Bye!",
+            "empty"             : "",
+            "path"              : "/foo/bar",
+            "x"                 : "1024",
+            "y"                 : "768",
+            "list"              : ["red", "green", "blue"],
+            "keys"              : { "semi" : ";", "dot" : ".", "comma" : ","},
+            "example"           : "red",
+            "searchTerms"       : "uri templates",
+            "~thing"            : "some-user",
+            "default-graph-uri" : ["http://www.example/book/","http://www.example/papers/"],
+            "query"             : "PREFIX dc: <http://purl.org/dc/elements/1.1/> SELECT ?book ?who WHERE { ?book dc:creator ?who }"
+
+        },
+        "testcases":[
+            [ "{/id*",  false  ],
+            [ "/id*}",  false  ],
+            [ "{/?id}",  false  ],
+            [ "{var:prefix}",  false  ],
+            [ "{hello:2*}",  false  ] ,
+            [ "{??hello}",  false  ] ,
+            [ "{!hello}",  false  ] ,
+            [ "{with space}", false],
+            [ "{ leading_space}", false],
+            [ "{trailing_space }", false],
+            [ "{=path}",  false  ] ,
+            [ "{$var}", false ],
+            [ "{|var*}", false ],
+            [ "{*keys?}",  false  ],
+            [ "{?empty=default,var}",  false  ],
+            [ "{var}{-prefix|/-/|var}" , false ],
+            [ "?q={searchTerms}&amp;c={example:color?}" , false ],
+            [ "x{?empty|foo=none}" , false ],
+            [ "/h{#hello+}" , false ],
+            [ "/h#{hello+}" , false ],
+            [ "{keys:1}",  false  ],
+            [ "{+keys:1}",  false  ],
+            [ "{;keys:1*}",  false  ],
+            [ "?{-join|&|var,list}" , false ],
+            [ "/people/{~thing}", false],
+            [ "/{default-graph-uri}", false ],
+            [ "/sparql{?query,default-graph-uri}", false ],
+            [ "/sparql{?query){&default-graph-uri*}", false ],
+            [ "/resolution{?x, y}" , false ]
+
+        ]
+    }
+}

--- a/feignx-core/src/test/resources/template/spec-examples-by-section.json
+++ b/feignx-core/src/test/resources/template/spec-examples-by-section.json
@@ -1,0 +1,439 @@
+{
+  "3.2.1 Variable Expansion" :
+  {
+    "variables": {
+       "count"      : ["one", "two", "three"],
+       "dom"        : ["example", "com"],
+       "dub"        : "me/too",
+       "hello"      : "Hello World!",
+       "half"       : "50%",
+       "var"        : "value",
+       "who"        : "fred",
+       "base"       : "http://example.com/home/",
+       "path"       : "/foo/bar",
+       "list"       : ["red", "green", "blue"],
+       "keys"       : { "semi" : ";", "dot" : ".", "comma" : ","},
+       "v"          : "6",
+       "x"          : "1024",
+       "y"          : "768",
+       "empty"      : "",
+       "empty_keys" : [],
+       "undef"      : null
+     },
+     "testcases" : [
+        ["{count}", "one,two,three"],
+        ["{count*}", "one,two,three"],
+        ["{/count}", "/one,two,three"],
+        ["{/count*}", "/one/two/three"],
+        ["{;count}", ";count=one,two,three"],
+        ["{;count*}", ";count=one;count=two;count=three"],
+        ["{?count}", "?count=one,two,three"],
+        ["{?count*}", "?count=one&count=two&count=three"],
+        ["{&count*}", "&count=one&count=two&count=three"]
+      ]
+  },
+  "3.2.2 Simple String Expansion" :
+  {
+    "variables": {
+       "count"      : ["one", "two", "three"],
+       "dom"        : ["example", "com"],
+       "dub"        : "me/too",
+       "hello"      : "Hello World!",
+       "half"       : "50%",
+       "var"        : "value",
+       "who"        : "fred",
+       "base"       : "http://example.com/home/",
+       "path"       : "/foo/bar",
+       "list"       : ["red", "green", "blue"],
+       "keys"       : { "semi" : ";", "dot" : ".", "comma" : ","},
+       "v"          : "6",
+       "x"          : "1024",
+       "y"          : "768",
+       "empty"      : "",
+       "empty_keys" : [],
+       "undef"      : null
+     },
+     "testcases" : [
+        ["{var}", "value"],
+        ["{hello}", "Hello%20World%21"],
+        ["{half}", "50%25"],
+        ["O{empty}X", "OX"],
+        ["O{undef}X", "OX"],
+        ["{x,y}", "1024,768"],
+        ["{x,hello,y}", "1024,Hello%20World%21,768"],
+        ["?{x,empty}", "?1024,"],
+        ["?{x,undef}", "?1024"],
+        ["?{undef,y}", "?768"],
+        ["{var:3}", "val"],
+        ["{var:30}", "value"],
+        ["{list}", "red,green,blue"],
+        ["{list*}", "red,green,blue"],
+        ["{keys}", [
+          "comma,%2C,dot,.,semi,%3B",
+          "comma,%2C,semi,%3B,dot,.",
+          "dot,.,comma,%2C,semi,%3B",
+          "dot,.,semi,%3B,comma,%2C",
+          "semi,%3B,comma,%2C,dot,.",
+          "semi,%3B,dot,.,comma,%2C"
+        ]],
+        ["{keys*}", [
+          "comma=%2C,dot=.,semi=%3B",
+          "comma=%2C,semi=%3B,dot=.",
+          "dot=.,comma=%2C,semi=%3B",
+          "dot=.,semi=%3B,comma=%2C",
+          "semi=%3B,comma=%2C,dot=.",
+          "semi=%3B,dot=.,comma=%2C"
+        ]]
+     ]
+  },
+  "3.2.3 Reserved Expansion" :
+  {
+    "variables": {
+       "count"      : ["one", "two", "three"],
+       "dom"        : ["example", "com"],
+       "dub"        : "me/too",
+       "hello"      : "Hello World!",
+       "half"       : "50%",
+       "var"        : "value",
+       "who"        : "fred",
+       "base"       : "http://example.com/home/",
+       "path"       : "/foo/bar",
+       "list"       : ["red", "green", "blue"],
+       "keys"       : { "semi" : ";", "dot" : ".", "comma" : ","},
+       "v"          : "6",
+       "x"          : "1024",
+       "y"          : "768",
+       "empty"      : "",
+       "empty_keys" : [],
+       "undef"      : null
+     },
+     "testcases" : [
+        ["{+var}", "value"],
+        ["{/var,empty}", "/value/"],
+        ["{/var,undef}", "/value"],
+        ["{+hello}", "Hello%20World!"],
+        ["{+half}", "50%25"],
+        ["{base}index", "http%3A%2F%2Fexample.com%2Fhome%2Findex"],
+        ["{+base}index", "http://example.com/home/index"],
+        ["O{+empty}X", "OX"],
+        ["O{+undef}X", "OX"],
+        ["{+path}/here", "/foo/bar/here"],
+        ["{+path:6}/here", "/foo/b/here"],
+        ["here?ref={+path}", "here?ref=/foo/bar"],
+        ["up{+path}{var}/here", "up/foo/barvalue/here"],
+        ["{+x,hello,y}", "1024,Hello%20World!,768"],
+        ["{+path,x}/here", "/foo/bar,1024/here"],
+        ["{+list}", "red,green,blue"],
+        ["{+list*}", "red,green,blue"],
+        ["{+keys}", [
+          "comma,,,dot,.,semi,;",
+          "comma,,,semi,;,dot,.",
+          "dot,.,comma,,,semi,;",
+          "dot,.,semi,;,comma,,",
+          "semi,;,comma,,,dot,.",
+          "semi,;,dot,.,comma,,"
+        ]],
+        ["{+keys*}", [
+          "comma=,,dot=.,semi=;",
+          "comma=,,semi=;,dot=.",
+          "dot=.,comma=,,semi=;",
+          "dot=.,semi=;,comma=,",
+          "semi=;,comma=,,dot=.",
+          "semi=;,dot=.,comma=,"
+        ]]
+     ]
+  },
+  "3.2.4 Fragment Expansion" :
+  {
+    "variables": {
+       "count"      : ["one", "two", "three"],
+       "dom"        : ["example", "com"],
+       "dub"        : "me/too",
+       "hello"      : "Hello World!",
+       "half"       : "50%",
+       "var"        : "value",
+       "who"        : "fred",
+       "base"       : "http://example.com/home/",
+       "path"       : "/foo/bar",
+       "list"       : ["red", "green", "blue"],
+       "keys"       : { "semi" : ";", "dot" : ".", "comma" : ","},
+       "v"          : "6",
+       "x"          : "1024",
+       "y"          : "768",
+       "empty"      : "",
+       "empty_keys" : [],
+       "undef"      : null
+     },
+     "testcases" : [
+        ["{#var}", "#value"],
+        ["{#hello}", "#Hello%20World!"],
+        ["{#half}", "#50%25"],
+        ["foo{#empty}", "foo#"],
+        ["foo{#undef}", "foo"],
+        ["{#x,hello,y}", "#1024,Hello%20World!,768"],
+        ["{#path,x}/here", "#/foo/bar,1024/here"],
+        ["{#path:6}/here", "#/foo/b/here"],
+        ["{#list}", "#red,green,blue"],
+        ["{#list*}", "#red,green,blue"],
+        ["{#keys}", [
+          "#comma,,,dot,.,semi,;",
+          "#comma,,,semi,;,dot,.",
+          "#dot,.,comma,,,semi,;",
+          "#dot,.,semi,;,comma,,",
+          "#semi,;,comma,,,dot,.",
+          "#semi,;,dot,.,comma,,"
+        ]]
+    ]
+  },
+  "3.2.5 Label Expansion with Dot-Prefix" :
+  {
+    "variables": {
+       "count"      : ["one", "two", "three"],
+       "dom"        : ["example", "com"],
+       "dub"        : "me/too",
+       "hello"      : "Hello World!",
+       "half"       : "50%",
+       "var"        : "value",
+       "who"        : "fred",
+       "base"       : "http://example.com/home/",
+       "path"       : "/foo/bar",
+       "list"       : ["red", "green", "blue"],
+       "keys"       : { "semi" : ";", "dot" : ".", "comma" : ","},
+       "v"          : "6",
+       "x"          : "1024",
+       "y"          : "768",
+       "empty"      : "",
+       "empty_keys" : [],
+       "undef"      : null
+    },
+    "testcases" : [
+       ["{.who}", ".fred"],
+       ["{.who,who}", ".fred.fred"],
+       ["{.half,who}", ".50%25.fred"],
+       ["www{.dom*}", "www.example.com"],
+       ["X{.var}", "X.value"],
+       ["X{.var:3}", "X.val"],
+       ["X{.empty}", "X."],
+       ["X{.undef}", "X"],
+       ["X{.list}", "X.red,green,blue"],
+       ["X{.list*}", "X.red.green.blue"],
+       ["{#keys}", [
+        "#comma,,,dot,.,semi,;",
+        "#comma,,,semi,;,dot,.",
+        "#dot,.,comma,,,semi,;",
+        "#dot,.,semi,;,comma,,",
+        "#semi,;,comma,,,dot,.",
+        "#semi,;,dot,.,comma,,"
+       ]],
+       ["{#keys*}", [
+        "#comma=,,dot=.,semi=;",
+        "#comma=,,semi=;,dot=.",
+        "#dot=.,comma=,,semi=;",
+        "#dot=.,semi=;,comma=,",
+        "#semi=;,comma=,,dot=.",
+        "#semi=;,dot=.,comma=,"
+       ]],
+       ["X{.empty_keys}", "X"],
+       ["X{.empty_keys*}", "X"]
+    ]
+  },
+  "3.2.6 Path Segment Expansion" :
+  {
+    "variables": {
+       "count"      : ["one", "two", "three"],
+       "dom"        : ["example", "com"],
+       "dub"        : "me/too",
+       "hello"      : "Hello World!",
+       "half"       : "50%",
+       "var"        : "value",
+       "who"        : "fred",
+       "base"       : "http://example.com/home/",
+       "path"       : "/foo/bar",
+       "list"       : ["red", "green", "blue"],
+       "keys"       : { "semi" : ";", "dot" : ".", "comma" : ","},
+       "v"          : "6",
+       "x"          : "1024",
+       "y"          : "768",
+       "empty"      : "",
+       "empty_keys" : [],
+       "undef"      : null
+     },
+     "testcases" : [
+       ["{/who}", "/fred"],
+       ["{/who,who}", "/fred/fred"],
+       ["{/half,who}", "/50%25/fred"],
+       ["{/who,dub}", "/fred/me%2Ftoo"],
+       ["{/var}", "/value"],
+       ["{/var,empty}", "/value/"],
+       ["{/var,undef}", "/value"],
+       ["{/var,x}/here", "/value/1024/here"],
+       ["{/var:1,var}", "/v/value"],
+       ["{/list}", "/red,green,blue"],
+       ["{/list*}", "/red/green/blue"],
+       ["{/list*,path:4}", "/red/green/blue/%2Ffoo"],
+       ["{/keys}", [
+        "/comma,%2C,dot,.,semi,%3B",
+        "/comma,%2C,semi,%3B,dot,.",
+        "/dot,.,comma,%2C,semi,%3B",
+        "/dot,.,semi,%3B,comma,%2C",
+        "/semi,%3B,comma,%2C,dot,.",
+        "/semi,%3B,dot,.,comma,%2C"
+       ]],
+       ["{/keys*}", [ 
+        "/comma=%2C/dot=./semi=%3B",
+        "/comma=%2C/semi=%3B/dot=.",
+        "/dot=./comma=%2C/semi=%3B",
+        "/dot=./semi=%3B/comma=%2C",
+        "/semi=%3B/comma=%2C/dot=.",
+        "/semi=%3B/dot=./comma=%2C"
+       ]]
+     ]
+  },
+  "3.2.7 Path-Style Parameter Expansion" :
+  {
+    "variables": {
+       "count"      : ["one", "two", "three"],
+       "dom"        : ["example", "com"],
+       "dub"        : "me/too",
+       "hello"      : "Hello World!",
+       "half"       : "50%",
+       "var"        : "value",
+       "who"        : "fred",
+       "base"       : "http://example.com/home/",
+       "path"       : "/foo/bar",
+       "list"       : ["red", "green", "blue"],
+       "keys"       : { "semi" : ";", "dot" : ".", "comma" : ","},
+       "v"          : "6",
+       "x"          : "1024",
+       "y"          : "768",
+       "empty"      : "",
+       "empty_keys" : [],
+       "undef"      : null
+     },
+     "testcases" : [
+        ["{;who}", ";who=fred"],
+        ["{;half}", ";half=50%25"],
+        ["{;empty}", ";empty"],
+        ["{;hello:5}", ";hello=Hello"],
+        ["{;v,empty,who}", ";v=6;empty;who=fred"],
+        ["{;v,bar,who}", ";v=6;who=fred"],
+        ["{;x,y}", ";x=1024;y=768"],
+        ["{;x,y,empty}", ";x=1024;y=768;empty"],
+        ["{;x,y,undef}", ";x=1024;y=768"],
+        ["{;list}", ";list=red,green,blue"],
+        ["{;list*}", ";list=red;list=green;list=blue"],
+        ["{;keys}", [ 
+          ";keys=comma,%2C,dot,.,semi,%3B",
+          ";keys=comma,%2C,semi,%3B,dot,.",
+          ";keys=dot,.,comma,%2C,semi,%3B",
+          ";keys=dot,.,semi,%3B,comma,%2C",
+          ";keys=semi,%3B,comma,%2C,dot,.",
+          ";keys=semi,%3B,dot,.,comma,%2C"
+        ]],
+        ["{;keys*}", [ 
+          ";comma=%2C;dot=.;semi=%3B",
+          ";comma=%2C;semi=%3B;dot=.",
+          ";dot=.;comma=%2C;semi=%3B",
+          ";dot=.;semi=%3B;comma=%2C",
+          ";semi=%3B;comma=%2C;dot=.",
+          ";semi=%3B;dot=.;comma=%2C"
+        ]]
+     ]
+  },
+  "3.2.8 Form-Style Query Expansion" :
+  {
+    "variables": {
+       "count"      : ["one", "two", "three"],
+       "dom"        : ["example", "com"],
+       "dub"        : "me/too",
+       "hello"      : "Hello World!",
+       "half"       : "50%",
+       "var"        : "value",
+       "who"        : "fred",
+       "base"       : "http://example.com/home/",
+       "path"       : "/foo/bar",
+       "list"       : ["red", "green", "blue"],
+       "keys"       : { "semi" : ";", "dot" : ".", "comma" : ","},
+       "v"          : "6",
+       "x"          : "1024",
+       "y"          : "768",
+       "empty"      : "",
+       "empty_keys" : [],
+       "undef"      : null
+     },
+     "testcases" : [
+        ["{?who}", "?who=fred"],
+        ["{?half}", "?half=50%25"],
+        ["{?x,y}", "?x=1024&y=768"],
+        ["{?x,y,empty}", "?x=1024&y=768&empty="],
+        ["{?x,y,undef}", "?x=1024&y=768"],
+        ["{?var:3}", "?var=val"],
+        ["{?list}", "?list=red,green,blue"],
+        ["{?list*}", "?list=red&list=green&list=blue"],
+        ["{?keys}", [ 
+          "?keys=comma,%2C,dot,.,semi,%3B",
+          "?keys=comma,%2C,semi,%3B,dot,.",
+          "?keys=dot,.,comma,%2C,semi,%3B",
+          "?keys=dot,.,semi,%3B,comma,%2C",
+          "?keys=semi,%3B,comma,%2C,dot,.",
+          "?keys=semi,%3B,dot,.,comma,%2C"
+        ]],
+        ["{?keys*}", [ 
+          "?comma=%2C&dot=.&semi=%3B",
+          "?comma=%2C&semi=%3B&dot=.",
+          "?dot=.&comma=%2C&semi=%3B",
+          "?dot=.&semi=%3B&comma=%2C",
+          "?semi=%3B&comma=%2C&dot=.",
+          "?semi=%3B&dot=.&comma=%2C"
+        ]]
+     ]
+  },
+  "3.2.9 Form-Style Query Continuation" :
+  {
+    "variables": {
+       "count"      : ["one", "two", "three"],
+       "dom"        : ["example", "com"],
+       "dub"        : "me/too",
+       "hello"      : "Hello World!",
+       "half"       : "50%",
+       "var"        : "value",
+       "who"        : "fred",
+       "base"       : "http://example.com/home/",
+       "path"       : "/foo/bar",
+       "list"       : ["red", "green", "blue"],
+       "keys"       : { "semi" : ";", "dot" : ".", "comma" : ","},
+       "v"          : "6",
+       "x"          : "1024",
+       "y"          : "768",
+       "empty"      : "",
+       "empty_keys" : [],
+       "undef"      : null
+     },
+     "testcases" : [
+          ["{&who}", "&who=fred"],
+          ["{&half}", "&half=50%25"],
+          ["?fixed=yes{&x}", "?fixed=yes&x=1024"],
+          ["{&var:3}", "&var=val"],
+          ["{&x,y,empty}", "&x=1024&y=768&empty="],
+          ["{&x,y,undef}", "&x=1024&y=768"],
+          ["{&list}", "&list=red,green,blue"],
+          ["{&list*}", "&list=red&list=green&list=blue"],
+          ["{&keys}", [ 
+            "&keys=comma,%2C,dot,.,semi,%3B",
+            "&keys=comma,%2C,semi,%3B,dot,.",
+            "&keys=dot,.,comma,%2C,semi,%3B",
+            "&keys=dot,.,semi,%3B,comma,%2C",
+            "&keys=semi,%3B,comma,%2C,dot,.",
+            "&keys=semi,%3B,dot,.,comma,%2C"
+          ]],
+          ["{&keys*}", [ 
+            "&comma=%2C&dot=.&semi=%3B",
+            "&comma=%2C&semi=%3B&dot=.",
+            "&dot=.&comma=%2C&semi=%3B",
+            "&dot=.&semi=%3B&comma=%2C",
+            "&semi=%3B&comma=%2C&dot=.",
+            "&semi=%3B&dot=.&comma=%2C"
+          ]]
+     ]
+  }
+}

--- a/feignx-core/src/test/resources/template/spec-examples.json
+++ b/feignx-core/src/test/resources/template/spec-examples.json
@@ -1,0 +1,218 @@
+{
+  "Level 1 Examples" :
+  {
+    "level": 1,
+    "variables": {
+       "var"   : "value",
+       "hello" : "Hello World!"
+     },
+     "testcases" : [
+        ["{var}", "value"],
+        ["{hello}", "Hello%20World%21"]
+     ]
+  },
+  "Level 2 Examples" :
+  {
+    "level": 2,
+    "variables": {
+       "var"   : "value",
+       "hello" : "Hello World!",
+       "path"  : "/foo/bar"
+     },
+     "testcases" : [
+        ["{+var}", "value"],
+        ["{+hello}", "Hello%20World!"],
+        ["{+path}/here", "/foo/bar/here"],
+        ["here?ref={+path}", "here?ref=/foo/bar"]
+     ]
+  },
+  "Level 3 Examples" :
+  {
+    "level": 3,
+    "variables": {
+       "var"   : "value",
+       "hello" : "Hello World!",
+       "empty" : "",
+       "path"  : "/foo/bar",
+       "x"     : "1024",
+       "y"     : "768"
+     },
+     "testcases" : [
+        ["map?{x,y}", "map?1024,768"],
+        ["{x,hello,y}", "1024,Hello%20World%21,768"],
+        ["{+x,hello,y}", "1024,Hello%20World!,768"],
+        ["{+path,x}/here", "/foo/bar,1024/here"],
+        ["{#x,hello,y}", "#1024,Hello%20World!,768"],
+        ["{#path,x}/here", "#/foo/bar,1024/here"],
+        ["X{.var}", "X.value"],
+        ["X{.x,y}", "X.1024.768"],
+        ["{/var}", "/value"],
+        ["{/var,x}/here", "/value/1024/here"],
+        ["{;x,y}", ";x=1024;y=768"],
+        ["{;x,y,empty}", ";x=1024;y=768;empty"],
+        ["{?x,y}", "?x=1024&y=768"],
+        ["{?x,y,empty}", "?x=1024&y=768&empty="],
+        ["?fixed=yes{&x}", "?fixed=yes&x=1024"],
+        ["{&x,y,empty}", "&x=1024&y=768&empty="]
+     ]
+  },
+  "Level 4 Examples" :
+  {
+    "level": 4,
+    "variables": {
+      "var": "value",
+      "hello": "Hello World!",
+      "path": "/foo/bar",
+      "list": ["red", "green", "blue"],
+      "keys": {"semi": ";", "dot": ".", "comma":","}
+    },
+    "testcases": [
+      ["{var:3}", "val"],
+      ["{var:30}", "value"],
+      ["{list}", "red,green,blue"],
+      ["{list*}", "red,green,blue"],
+      ["{keys}", [
+        "comma,%2C,dot,.,semi,%3B",
+        "comma,%2C,semi,%3B,dot,.",
+        "dot,.,comma,%2C,semi,%3B",
+        "dot,.,semi,%3B,comma,%2C",
+        "semi,%3B,comma,%2C,dot,.",
+        "semi,%3B,dot,.,comma,%2C"
+      ]],
+      ["{keys*}", [
+        "comma=%2C,dot=.,semi=%3B",
+        "comma=%2C,semi=%3B,dot=.",
+        "dot=.,comma=%2C,semi=%3B",
+        "dot=.,semi=%3B,comma=%2C",
+        "semi=%3B,comma=%2C,dot=.",
+        "semi=%3B,dot=.,comma=%2C"
+      ]],
+      ["{+path:6}/here", "/foo/b/here"],
+      ["{+list}", "red,green,blue"],
+      ["{+list*}", "red,green,blue"],
+      ["{+keys}", [
+        "comma,,,dot,.,semi,;",
+        "comma,,,semi,;,dot,.",
+        "dot,.,comma,,,semi,;",
+        "dot,.,semi,;,comma,,",
+        "semi,;,comma,,,dot,.",
+        "semi,;,dot,.,comma,,"
+      ]],
+      ["{+keys*}", [
+        "comma=,,dot=.,semi=;",
+        "comma=,,semi=;,dot=.",
+        "dot=.,comma=,,semi=;",
+        "dot=.,semi=;,comma=,",
+        "semi=;,comma=,,dot=.",
+        "semi=;,dot=.,comma=,"
+      ]],
+      ["{#path:6}/here", "#/foo/b/here"],
+      ["{#list}", "#red,green,blue"],
+      ["{#list*}", "#red,green,blue"],
+      ["{#keys}", [
+        "#comma,,,dot,.,semi,;",
+        "#comma,,,semi,;,dot,.",
+        "#dot,.,comma,,,semi,;",
+        "#dot,.,semi,;,comma,,",
+        "#semi,;,comma,,,dot,.",
+        "#semi,;,dot,.,comma,,"
+      ]],
+      ["{#keys*}", [
+        "#comma=,,dot=.,semi=;",
+        "#comma=,,semi=;,dot=.",
+        "#dot=.,comma=,,semi=;",
+        "#dot=.,semi=;,comma=,",
+        "#semi=;,comma=,,dot=.",
+        "#semi=;,dot=.,comma=,"
+      ]],
+      ["X{.var:3}", "X.val"],
+      ["X{.list}", "X.red,green,blue"],
+      ["X{.list*}", "X.red.green.blue"],
+      ["X{.keys}", [ 
+        "X.comma,%2C,dot,.,semi,%3B",
+        "X.comma,%2C,semi,%3B,dot,.",
+        "X.dot,.,comma,%2C,semi,%3B",
+        "X.dot,.,semi,%3B,comma,%2C",
+        "X.semi,%3B,comma,%2C,dot,.",
+        "X.semi,%3B,dot,.,comma,%2C"
+      ]],
+      ["{/var:1,var}", "/v/value"],
+      ["{/list}", "/red,green,blue"],
+      ["{/list*}", "/red/green/blue"],
+      ["{/list*,path:4}", "/red/green/blue/%2Ffoo"],
+      ["{/keys}", [
+        "/comma,%2C,dot,.,semi,%3B",
+        "/comma,%2C,semi,%3B,dot,.",
+        "/dot,.,comma,%2C,semi,%3B",
+        "/dot,.,semi,%3B,comma,%2C",
+        "/semi,%3B,comma,%2C,dot,.",
+        "/semi,%3B,dot,.,comma,%2C"
+      ]],
+      ["{/keys*}", [ 
+        "/comma=%2C/dot=./semi=%3B",
+        "/comma=%2C/semi=%3B/dot=.",
+        "/dot=./comma=%2C/semi=%3B",
+        "/dot=./semi=%3B/comma=%2C",
+        "/semi=%3B/comma=%2C/dot=.",
+        "/semi=%3B/dot=./comma=%2C"
+      ]],
+      ["{;hello:5}", ";hello=Hello"],
+      ["{;list}", ";list=red,green,blue"],
+      ["{;list*}", ";list=red;list=green;list=blue"],
+      ["{;keys}", [ 
+        ";keys=comma,%2C,dot,.,semi,%3B",
+        ";keys=comma,%2C,semi,%3B,dot,.",
+        ";keys=dot,.,comma,%2C,semi,%3B",
+        ";keys=dot,.,semi,%3B,comma,%2C",
+        ";keys=semi,%3B,comma,%2C,dot,.",
+        ";keys=semi,%3B,dot,.,comma,%2C"
+      ]],
+      ["{;keys*}", [ 
+        ";comma=%2C;dot=.;semi=%3B",
+        ";comma=%2C;semi=%3B;dot=.",
+        ";dot=.;comma=%2C;semi=%3B",
+        ";dot=.;semi=%3B;comma=%2C",
+        ";semi=%3B;comma=%2C;dot=.",
+        ";semi=%3B;dot=.;comma=%2C"
+      ]],
+      ["{?var:3}", "?var=val"],
+      ["{?list}", "?list=red,green,blue"],
+      ["{?list*}", "?list=red&list=green&list=blue"],
+      ["{?keys}", [ 
+        "?keys=comma,%2C,dot,.,semi,%3B",
+        "?keys=comma,%2C,semi,%3B,dot,.",
+        "?keys=dot,.,comma,%2C,semi,%3B",
+        "?keys=dot,.,semi,%3B,comma,%2C",
+        "?keys=semi,%3B,comma,%2C,dot,.",
+        "?keys=semi,%3B,dot,.,comma,%2C"
+      ]],
+      ["{?keys*}", [ 
+        "?comma=%2C&dot=.&semi=%3B",
+        "?comma=%2C&semi=%3B&dot=.",
+        "?dot=.&comma=%2C&semi=%3B",
+        "?dot=.&semi=%3B&comma=%2C",
+        "?semi=%3B&comma=%2C&dot=.",
+        "?semi=%3B&dot=.&comma=%2C"
+      ]],
+      ["{&var:3}", "&var=val"],
+      ["{&list}", "&list=red,green,blue"],
+      ["{&list*}", "&list=red&list=green&list=blue"],
+      ["{&keys}", [ 
+        "&keys=comma,%2C,dot,.,semi,%3B",
+        "&keys=comma,%2C,semi,%3B,dot,.",
+        "&keys=dot,.,comma,%2C,semi,%3B",
+        "&keys=dot,.,semi,%3B,comma,%2C",
+        "&keys=semi,%3B,comma,%2C,dot,.",
+        "&keys=semi,%3B,dot,.,comma,%2C"
+      ]],
+      ["{&keys*}", [ 
+        "&comma=%2C&dot=.&semi=%3B",
+        "&comma=%2C&semi=%3B&dot=.",
+        "&dot=.&comma=%2C&semi=%3B",
+        "&dot=.&semi=%3B&comma=%2C",
+        "&semi=%3B&comma=%2C&dot=.",
+        "&semi=%3B&dot=.&comma=%2C"
+      ]]
+    ]
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.9.8</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
Incorporating the Uri Template TCK available on GitHub.  This
TCK contains expression for every level, including additional
community provided examples.

I've also added some Feign Specific test cases, specifically
around complex variable names.

Expressions that contain multiple values are represented by a
CompositeExpression, in order to comply with the specification.